### PR TITLE
Fix course instructor dropdown and admin user details

### DIFF
--- a/Controllers/AccountController.cs
+++ b/Controllers/AccountController.cs
@@ -15,6 +15,7 @@ namespace Training_Management_System_ITI_Project.Controllers
     private readonly UserManager<ApplicationUser> _userManager;
     private readonly SignInManager<ApplicationUser> _signInManager;
     private readonly ILogger<AccountController> _logger;
+    private readonly Training_Management_System_ITI_Project.Data.ApplicationDbContext _dbContext;
 
     /// <summary>
     /// Initializes the AccountController with required Identity services
@@ -25,11 +26,13 @@ namespace Training_Management_System_ITI_Project.Controllers
     public AccountController(
         UserManager<ApplicationUser> userManager,
         SignInManager<ApplicationUser> signInManager,
-        ILogger<AccountController> logger)
+        ILogger<AccountController> logger,
+        Training_Management_System_ITI_Project.Data.ApplicationDbContext dbContext)
     {
       _userManager = userManager;
       _signInManager = signInManager;
       _logger = logger;
+      _dbContext = dbContext;
     }
 
     /// <summary>
@@ -164,6 +167,10 @@ namespace Training_Management_System_ITI_Project.Controllers
         // Add user to appropriate role
         await _userManager.AddToRoleAsync(user, model.Role.ToString());
 
+        // Mirror to LegacyUsers for legacy features (e.g., courses instructor list)
+        _dbContext.LegacyUsers.Add(new User { Name = user.FullName, Email = user.Email!, Role = user.Role });
+        await _dbContext.SaveChangesAsync();
+
         TempData["SuccessMessage"] = $"User {model.FullName} has been created successfully.";
         return RedirectToAction("ManageUsers");
       }
@@ -224,6 +231,10 @@ namespace Training_Management_System_ITI_Project.Controllers
 
         // Add user to Trainee role
         await _userManager.AddToRoleAsync(user, UserRole.Trainee.ToString());
+
+        // Mirror to LegacyUsers for legacy features
+        _dbContext.LegacyUsers.Add(new User { Name = user.FullName, Email = user.Email!, Role = user.Role });
+        await _dbContext.SaveChangesAsync();
 
         // Auto-login the new student
         await _signInManager.SignInAsync(user, isPersistent: false);
@@ -452,6 +463,47 @@ namespace Training_Management_System_ITI_Project.Controllers
       {
         ModelState.AddModelError(string.Empty, error.Description);
       }
+
+      return View(model);
+    }
+
+    /// <summary>
+    /// Displays user details for administrators
+    /// </summary>
+    /// <param name="id">ID of the user to view</param>
+    /// <returns>User details view or access denied</returns>
+    [HttpGet]
+    [Authorize(Roles = "Admin,SuperAdmin")]
+    public async Task<IActionResult> UserDetails(string id)
+    {
+      if (string.IsNullOrWhiteSpace(id))
+      {
+        return NotFound();
+      }
+
+      var currentUser = await _userManager.GetUserAsync(User);
+      var targetUser = await _userManager.FindByIdAsync(id);
+      if (targetUser == null)
+      {
+        return NotFound();
+      }
+
+      // Non-SuperAdmins cannot view SuperAdmins
+      if (targetUser.Role == UserRole.SuperAdmin && currentUser?.Role != UserRole.SuperAdmin)
+      {
+        return Forbid();
+      }
+
+      var model = new UserProfileViewModel
+      {
+        Id = targetUser.Id,
+        FullName = targetUser.FullName,
+        Email = targetUser.Email!,
+        Role = targetUser.Role,
+        IsActive = targetUser.IsActive,
+        CreatedAt = targetUser.CreatedAt,
+        UpdatedAt = targetUser.UpdatedAt
+      };
 
       return View(model);
     }

--- a/Program.cs
+++ b/Program.cs
@@ -128,6 +128,9 @@ namespace Training_Management_System_ITI_Project
 
       // Create default super admin user
       await CreateDefaultSuperAdminAsync(userManager);
+
+      // Sync Identity users into LegacyUsers for legacy features (e.g., instructor dropdowns)
+      await SyncLegacyUsersAsync(context, userManager);
     }
 
     /// <summary>
@@ -178,6 +181,60 @@ namespace Training_Management_System_ITI_Project
           Console.WriteLine("Please change this password immediately after first login!");
         }
       }
+    }
+
+    private static async Task SyncLegacyUsersAsync(ApplicationDbContext context, UserManager<ApplicationUser> userManager)
+    {
+      var identityUsers = userManager.Users.ToList();
+
+      // Load existing legacy users into lookup by email
+      var existingLegacyUsers = context.LegacyUsers.ToList();
+      var emailToLegacyUser = existingLegacyUsers.ToDictionary(u => u.Email.ToLower());
+
+      foreach (var identityUser in identityUsers)
+      {
+        var emailKey = (identityUser.Email ?? string.Empty).ToLower();
+        if (string.IsNullOrWhiteSpace(emailKey))
+        {
+          continue;
+        }
+
+        if (emailToLegacyUser.TryGetValue(emailKey, out var legacyUser))
+        {
+          // Update name/role if changed
+          var desiredName = identityUser.FullName;
+          var desiredRole = identityUser.Role;
+
+          bool changed = false;
+          if (legacyUser.Name != desiredName)
+          {
+            legacyUser.Name = desiredName;
+            changed = true;
+          }
+          if (legacyUser.Role != desiredRole)
+          {
+            legacyUser.Role = desiredRole;
+            changed = true;
+          }
+          if (changed)
+          {
+            context.LegacyUsers.Update(legacyUser);
+          }
+        }
+        else
+        {
+          // Insert new legacy user mapped from identity user
+          var newLegacyUser = new User
+          {
+            Name = identityUser.FullName,
+            Email = identityUser.Email!,
+            Role = identityUser.Role
+          };
+          context.LegacyUsers.Add(newLegacyUser);
+        }
+      }
+
+      await context.SaveChangesAsync();
     }
   }
 }

--- a/Views/Account/ManageUsers.cshtml
+++ b/Views/Account/ManageUsers.cshtml
@@ -118,9 +118,9 @@
                 </td>
                 <td>
                   <div class="btn-group btn-group-sm" role="group">
-                    <button type="button" class="btn btn-outline-primary" title="View Details">
+                    <a asp-action="UserDetails" asp-controller="Account" asp-route-id="@user.Id" class="btn btn-outline-primary" title="View Details">
                       <i class="fas fa-eye"></i>
-                    </button>
+                    </a>
                     <form asp-action="ToggleUserStatus" asp-controller="Account" method="post"
                       class="d-inline user-status-form">
                       <input type="hidden" name="userId" value="@user.Id" />

--- a/Views/Account/UserDetails.cshtml
+++ b/Views/Account/UserDetails.cshtml
@@ -1,0 +1,61 @@
+@model Training_Management_System_ITI_Project.ViewModels.UserProfileViewModel
+
+@{
+    ViewData["Title"] = "User Details";
+}
+
+<h2>User Details</h2>
+
+<div>
+    <hr />
+    <dl class="row">
+        <dt class="col-sm-2">Full Name</dt>
+        <dd class="col-sm-10">@Model.FullName</dd>
+
+        <dt class="col-sm-2">Email</dt>
+        <dd class="col-sm-10">@Model.Email</dd>
+
+        <dt class="col-sm-2">Role</dt>
+        <dd class="col-sm-10">
+            @switch (Model.Role)
+            {
+                case Training_Management_System_ITI_Project.Models.UserRole.SuperAdmin:
+                    <span class="badge bg-danger">Super Admin</span>
+                    break;
+                case Training_Management_System_ITI_Project.Models.UserRole.Admin:
+                    <span class="badge bg-warning text-dark">Admin</span>
+                    break;
+                case Training_Management_System_ITI_Project.Models.UserRole.Instructor:
+                    <span class="badge bg-info">Instructor</span>
+                    break;
+                case Training_Management_System_ITI_Project.Models.UserRole.Trainee:
+                    <span class="badge bg-success">Trainee</span>
+                    break;
+            }
+        </dd>
+
+        <dt class="col-sm-2">Status</dt>
+        <dd class="col-sm-10">
+            @if (Model.IsActive)
+            {
+                <span class="badge bg-success">Active</span>
+            }
+            else
+            {
+                <span class="badge bg-secondary">Inactive</span>
+            }
+        </dd>
+
+        <dt class="col-sm-2">Created</dt>
+        <dd class="col-sm-10">@Model.CreatedAt.ToString("MMM dd, yyyy")</dd>
+
+        @if (Model.UpdatedAt.HasValue)
+        {
+            <dt class="col-sm-2">Last Updated</dt>
+            <dd class="col-sm-10">@Model.UpdatedAt.Value.ToString("MMM dd, yyyy")</dd>
+        }
+    </dl>
+</div>
+<div>
+    <a asp-action="ManageUsers" class="btn btn-secondary">Back to List</a>
+</div>


### PR DESCRIPTION
Syncs Identity users to LegacyUsers for instructor dropdown and wires Super Admin "View details" button to a new user details page.

The instructor dropdown for course creation was empty because it relied on a `LegacyUsers` table, which was not being populated from the `AspNetUsers` (Identity) table. This PR introduces a sync mechanism at application startup and user registration to ensure `LegacyUsers` is up-to-date. Additionally, the "View Details" button in the Super Admin's "Manage Users" page was not wired to any action; this PR implements a new `UserDetails` action and view, and links the button to it.

---
<a href="https://cursor.com/background-agent?bcId=bc-a71e4acf-913f-48a5-ae7a-0097b01467cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a71e4acf-913f-48a5-ae7a-0097b01467cf">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

